### PR TITLE
fix k8s version vars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ module "k8s" {
   region        = "${var.region}"
   ssh_keys      = "${var.ssh_keys}"
   do_read_token = "${var.do_read_token}"
+  kubernetes_version = "${var.kubernetes_version}"
 
   # K8s specific
   apiserver_count  = "${var.apiserver_count}"

--- a/variables.tf
+++ b/variables.tf
@@ -42,6 +42,11 @@ variable kubelet_size {
   default     = "1gb"
 }
 
+variable kubernetes_version {
+  description = "Version of Kubernetes to install"
+  default     = "1.3.6"
+}
+
 variable apiserver_size {
   description = "Size of the apiserver"
   default     = "1gb"


### PR DESCRIPTION
this ensures the k8s version gets propagated to the template,
and to the hyperkube version string