### PR TITLE
Add cluster ids to droplet names

### DIFF
--- a/etcd/main.tf
+++ b/etcd/main.tf
@@ -12,8 +12,9 @@ resource digitalocean_droplet "etcd" {
   image              = "${var.image}"
   region             = "${var.region}"
   size               = "${var.size}"
-  name               = "${format("etcd-%02d", count.index + 1)}"
+  name               = "${format("etcd-%02d-%s", count.index + 1, var.cluster_id)}"
   ssh_keys           = ["${var.ssh_keys}"]
+  tags               = ["${var.cluster_tag}"]
   private_networking = true
 
   user_data = "${data.template_file.etcd.rendered}"

--- a/etcd/variables.tf
+++ b/etcd/variables.tf
@@ -8,6 +8,14 @@ variable region {
   default     = "sfo1"
 }
 
+variable cluster_id {
+  description = "A unique id for the cluster"
+}
+
+variable cluster_tag {
+  description = "A unique tag for the cluster"
+}
+
 variable do_read_token {
   description = "A read-only token for configuring droplan"
 }

--- a/k8s/main.tf
+++ b/k8s/main.tf
@@ -31,8 +31,9 @@ resource digitalocean_droplet "apiserver" {
   image              = "${var.image}"
   region             = "${var.region}"
   size               = "${var.apiserver_size}"
-  name               = "${format("apiserver-%02d", count.index + 1)}"
+  name               = "${format("apiserver-%02d-%s", count.index + 1, var.cluster_id)}"
   ssh_keys           = ["${var.ssh_keys}"]
+  tags               = ["${var.cluster_tag}"]
   private_networking = true
 
   user_data = "${data.template_file.apiserver.rendered}"
@@ -43,8 +44,9 @@ resource digitalocean_droplet "kubelet" {
   image              = "${var.image}"
   region             = "${var.region}"
   size               = "${var.kubelet_size}"
-  name               = "${format("kubelet-%02d", count.index + 1)}"
+  name               = "${format("kubelet-%02d-%s", count.index + 1, var.cluster_id)}"
   ssh_keys           = ["${var.ssh_keys}"]
+  tags               = ["${var.cluster_tag}"]
   private_networking = true
 
   user_data = "${data.template_file.kubelet.rendered}"
@@ -55,7 +57,8 @@ resource digitalocean_droplet "lb" {
   image              = "${var.lb_image}"
   size               = "${var.lb_size}"
   region             = "${var.region}"
-  name               = "${format("lb-%02d", count.index + 1)}"
+  name               = "${format("lb-%02d-%s", count.index + 1, var.cluster_id)}"
   ssh_keys           = ["${var.ssh_keys}"]
+  tags               = ["${var.cluster_tag}"]
   private_networking = true
 }

--- a/k8s/variables.tf
+++ b/k8s/variables.tf
@@ -7,6 +7,14 @@ variable ssh_keys {
   description = "SSH keys to use"
 }
 
+variable cluster_id {
+  description = "A unique id for the cluster"
+}
+
+variable cluster_tag {
+  description = "A unique tag for the cluster"
+}
+
 variable image {
   description = "Name of the image to use"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,11 @@
+resource random_id "cluster_id" {
+  byte_length = 16
+}
+
+resource digitalocean_tag "cluster_tag" {
+  name = "${format("k8s_cluster:%s", random_id.cluster_id.hex)}"
+}
+
 module "etcd" {
   source        = "./etcd"
   size          = "${var.etcd_size}"
@@ -9,6 +17,8 @@ module "etcd" {
   pod_network   = "${var.pod_network}"
   vxlan_id      = "${var.vxlan_id}"
   do_read_token = "${var.do_read_token}"
+  cluster_id    = "${random_id.cluster_id.hex}"
+  cluster_tag   = "${digitalocean_tag.cluster_tag.id}"
 }
 
 module "k8s" {
@@ -17,17 +27,19 @@ module "k8s" {
   region        = "${var.region}"
   ssh_keys      = "${var.ssh_keys}"
   do_read_token = "${var.do_read_token}"
-  kubernetes_version = "${var.kubernetes_version}"
+  cluster_id    = "${random_id.cluster_id.hex}"
+  cluster_tag   = "${digitalocean_tag.cluster_tag.id}"
 
   # K8s specific
-  apiserver_count  = "${var.apiserver_count}"
-  apiserver_size   = "${var.apiserver_size}"
-  kubelet_count    = "${var.kubelet_count}"
-  kubelet_size     = "${var.kubelet_size}"
-  service_ip_range = "${var.service_ip_range}"
-  k8s_service_ip   = "${var.k8s_service_ip}"
-  dns_service_ip   = "${var.dns_service_ip}"
-  etcd_server_urls = "${module.etcd.server_urls}"
+  kubernetes_version = "${var.kubernetes_version}"
+  apiserver_count    = "${var.apiserver_count}"
+  apiserver_size     = "${var.apiserver_size}"
+  kubelet_count      = "${var.kubelet_count}"
+  kubelet_size       = "${var.kubelet_size}"
+  service_ip_range   = "${var.service_ip_range}"
+  k8s_service_ip     = "${var.k8s_service_ip}"
+  dns_service_ip     = "${var.dns_service_ip}"
+  etcd_server_urls   = "${module.etcd.server_urls}"
 
   # Load balancer
   lb_image = "${var.lb_image}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -9,3 +9,7 @@ output "apiservers" {
 output "load-balancer" {
   value = "${module.k8s.load-balancer}"
 }
+
+output "cluster-tag" {
+  value = "${digitalocean_tag.cluster_tag.id}"
+}


### PR DESCRIPTION
This makes it less confusing for anyone looking at multiple clusters in
the DO UI since:

* each droplet has a unique cluster id appended to the name
* each droplet is also created with a `k8s_cluster` tag so you can
  quickly view the droplets in the cluster